### PR TITLE
Preserve JSONPath in argument type errors

### DIFF
--- a/src/Network/JsonRpc/Types.hs
+++ b/src/Network/JsonRpc/Types.hs
@@ -30,6 +30,12 @@ import qualified Data.Aeson.Key as A
 #endif
 import Data.Aeson ((.=), (.:), (.:?), (.!=))
 import Data.Aeson.Types (emptyObject)
+#if MIN_VERSION_aeson(2,1,2)
+-- iparse/IResult retain the JSONPath accumulated by (.:) and withObject,
+-- which A.fromJSON discards. formatError was first re-exported from
+-- Data.Aeson.Types in aeson 2.1.2.0.
+import Data.Aeson.Types (iparse, IResult (..), formatError)
+#endif
 import qualified Data.Vector as V
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -83,10 +89,20 @@ instance (A.FromJSON a, MethodParams f p m r) => MethodParams (a -> f) (a :+: p)
         name = paramName param
 
 parseArg :: A.FromJSON r => Text -> A.Value -> Either RpcError r
+#if MIN_VERSION_aeson(2,1,2)
+-- Use iparse so the JSONPath of a nested failure is preserved, turning bare
+-- "expected Number, got String" messages into
+-- "Error in $.products[0].price: expected Number, got String".
+parseArg name val = case iparse A.parseJSON val of
+                      IError path msg -> throwError $ argTypeError (formatError path msg)
+                      ISuccess x -> return x
+    where argTypeError = rpcErrorWithData (-32602) $ "Wrong type for argument: " `append` name
+#else
 parseArg name val = case A.fromJSON val of
                       A.Error msg -> throwError $ argTypeError msg
                       A.Success x -> return x
     where argTypeError = rpcErrorWithData (-32602) $ "Wrong type for argument: " `append` name
+#endif
 
 paramDefault :: Parameter a -> Either RpcError a
 paramDefault (Optional _ d) = Right d


### PR DESCRIPTION
`parseArg` uses `A.fromJSON`, which discards the JSONPath that `(.:)` and `withObject` accumulate. A bad *nested* argument therefore reports only `expected Number, got String`, with no indication of which field failed. This switches to `iparse`/`formatError` so the path is kept, producing actionable `-32602` errors like `Error in $.products[0].price: expected Number, got String`.

- Guarded by `MIN_VERSION_aeson(2,1,2)` — the first release that re-exports `formatError` from `Data.Aeson.Types`; older aeson keeps the current behavior.
- Library-only, no new dependencies.

Heads-up: I have no GHC/cabal locally, so this wasn't compiled on my end — relying on CI. The same change runs in production against aeson 2.2.x in my fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
